### PR TITLE
Disable data selection

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/chart/components/SuperChart.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/chart/components/SuperChart.tsx
@@ -97,6 +97,8 @@ export type Props = Omit<SuperChartCoreProps, 'chartProps'> &
      * Determines is the context menu related to the chart is open
      */
     inContextMenu?: boolean;
+    /** Prop that controls user selection of chart data */
+    dataSelectionMode?: string;
   };
 
 type PropsWithDefault = Props & Readonly<typeof defaultProps>;

--- a/superset-frontend/packages/superset-ui-core/src/chart/components/SuperChart.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/chart/components/SuperChart.tsx
@@ -97,8 +97,6 @@ export type Props = Omit<SuperChartCoreProps, 'chartProps'> &
      * Determines is the context menu related to the chart is open
      */
     inContextMenu?: boolean;
-    /** Prop that controls user selection of chart data */
-    dataSelectionMode?: string;
   };
 
 type PropsWithDefault = Props & Readonly<typeof defaultProps>;

--- a/superset-frontend/packages/superset-ui-core/src/chart/models/ChartProps.ts
+++ b/superset-frontend/packages/superset-ui-core/src/chart/models/ChartProps.ts
@@ -105,6 +105,8 @@ export interface ChartPropsConfig {
   inputRef?: RefObject<any>;
   /** Theme object */
   theme: SupersetTheme;
+  /** Set chart data selectable by user **/
+  dataSelectionMode?: string;
 }
 
 const DEFAULT_WIDTH = 800;
@@ -155,6 +157,8 @@ export default class ChartProps<FormData extends RawFormData = RawFormData> {
 
   theme: SupersetTheme;
 
+  dataSelectionMode?: string;
+
   constructor(config: ChartPropsConfig & { formData?: FormData } = {}) {
     const {
       annotationData = {},
@@ -176,6 +180,7 @@ export default class ChartProps<FormData extends RawFormData = RawFormData> {
       inContextMenu = false,
       emitCrossFilters = false,
       theme,
+      dataSelectionMode,
     } = config;
     this.width = width;
     this.height = height;
@@ -198,6 +203,7 @@ export default class ChartProps<FormData extends RawFormData = RawFormData> {
     this.inContextMenu = inContextMenu;
     this.emitCrossFilters = emitCrossFilters;
     this.theme = theme;
+    this.dataSelectionMode = dataSelectionMode;
   }
 }
 
@@ -223,6 +229,7 @@ ChartProps.createSelector = function create(): ChartPropsSelector {
     input => input.inContextMenu,
     input => input.emitCrossFilters,
     input => input.theme,
+    input => input.dataSelectionMode,
     (
       annotationData,
       datasource,
@@ -243,6 +250,7 @@ ChartProps.createSelector = function create(): ChartPropsSelector {
       inContextMenu,
       emitCrossFilters,
       theme,
+      dataSelectionMode,
     ) =>
       new ChartProps({
         annotationData,
@@ -264,6 +272,7 @@ ChartProps.createSelector = function create(): ChartPropsSelector {
         inContextMenu,
         emitCrossFilters,
         theme,
+	dataSelectionMode,
       }),
   );
 };

--- a/superset-frontend/packages/superset-ui-core/src/chart/models/ChartProps.ts
+++ b/superset-frontend/packages/superset-ui-core/src/chart/models/ChartProps.ts
@@ -105,7 +105,7 @@ export interface ChartPropsConfig {
   inputRef?: RefObject<any>;
   /** Theme object */
   theme: SupersetTheme;
-  /** Set chart data selectable by user **/
+  /** Set chart data selectable by user */
   dataSelectionMode?: string;
 }
 
@@ -272,7 +272,7 @@ ChartProps.createSelector = function create(): ChartPropsSelector {
         inContextMenu,
         emitCrossFilters,
         theme,
-	dataSelectionMode,
+        dataSelectionMode,
       }),
   );
 };

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/PivotTableChart.tsx
@@ -154,6 +154,7 @@ export default function PivotTableChart(props: PivotTableProps) {
     dateFormatters,
     onContextMenu,
     timeGrainSqla,
+    dataSelectionMode,
   } = props;
 
   const theme = useTheme();
@@ -555,6 +556,7 @@ export default function PivotTableChart(props: PivotTableProps) {
           subtotalOptions={subtotalOptions}
           namesMapping={verboseMap}
           onContextMenu={handleContextMenu}
+          dataSelectionMode={dataSelectionMode}
         />
       </PivotTableWrapper>
     </Styles>

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/transformProps.ts
@@ -81,6 +81,7 @@ export default function transformProps(chartProps: ChartProps<QueryFormData>) {
     filterState,
     datasource: { verboseMap = {}, columnFormats = {}, currencyFormats = {} },
     emitCrossFilters,
+    dataSelectionMode,
   } = chartProps;
   const { data, colnames, coltypes } = queriesData[0];
   const {
@@ -174,5 +175,6 @@ export default function transformProps(chartProps: ChartProps<QueryFormData>) {
     dateFormatters,
     onContextMenu,
     timeGrainSqla,
+    dataSelectionMode,
   };
 }

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/Styles.js
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/Styles.js
@@ -20,7 +20,7 @@
 import { css, styled } from '@superset-ui/core';
 
 export const Styles = styled.div`
-  ${({ theme, isDashboardEditMode }) => css`
+  ${({ theme, isDashboardEditMode, dataSelectionMode }) => css`
     table.pvtTable {
       position: ${isDashboardEditMode ? 'inherit' : 'relative'};
       width: calc(100% - ${theme.gridUnit}px);
@@ -30,7 +30,7 @@ export const Styles = styled.div`
       border-collapse: separate;
       font-family: ${theme.typography.families.sansSerif};
       line-height: 1.4;
-      user-select: none;
+      user-select: ${dataSelectionMode};
     }
 
     table thead {

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/Styles.js
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/Styles.js
@@ -30,6 +30,7 @@ export const Styles = styled.div`
       border-collapse: separate;
       font-family: ${theme.typography.families.sansSerif};
       line-height: 1.4;
+      user-select: none;
     }
 
     table thead {

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.jsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.jsx
@@ -899,7 +899,7 @@ export class TableRenderer extends Component {
     };
 
     return (
-      <Styles isDashboardEditMode={this.isDashboardEditMode()}>
+      <Styles isDashboardEditMode={this.isDashboardEditMode()} dataSelectionMode={this.props.dataSelectionMode}>
         <table className="pvtTable" role="grid">
           <thead>
             {colAttrs.map((c, j) =>

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.jsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.jsx
@@ -899,7 +899,10 @@ export class TableRenderer extends Component {
     };
 
     return (
-      <Styles isDashboardEditMode={this.isDashboardEditMode()} dataSelectionMode={this.props.dataSelectionMode}>
+      <Styles
+        isDashboardEditMode={this.isDashboardEditMode()}
+        dataSelectionMode={this.props.dataSelectionMode}
+      >
         <table className="pvtTable" role="grid">
           <thead>
             {colAttrs.map((c, j) =>

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/types.ts
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/types.ts
@@ -79,6 +79,7 @@ interface PivotTableCustomizeProps {
   dateFormatters: Record<string, DateFormatter | undefined>;
   legacy_order_by: QueryFormMetric[] | QueryFormMetric | null;
   order_desc: boolean;
+  dataSelectionMode: string;
   onContextMenu?: (
     clientX: number,
     clientY: number,

--- a/superset-frontend/plugins/plugin-chart-pivot-table/test/plugin/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/test/plugin/buildQuery.test.ts
@@ -54,6 +54,7 @@ const formData: PivotTableQueryFormData = {
   time_grain_sqla: TimeGranularity.MONTH,
   temporal_columns_lookup: { col1: true },
   currencyFormat: { symbol: 'USD', symbolPosition: 'prefix' },
+  dataSelectionMode: 'auto',
 };
 
 test('should build groupby with series in form data', () => {

--- a/superset-frontend/plugins/plugin-chart-table/src/Styles.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/Styles.tsx
@@ -118,5 +118,8 @@ export default styled.div`
     table .right-border-only:last-child {
       border-right: none;
     }
+    .no-select {
+      user-select: none;
+    }
   `}
 `;

--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -736,6 +736,8 @@ export default function TableChart<D extends DataRecord = DataRecord>(
         }
       }
 
+      className += ' no-select';
+
       return {
         id: String(i), // to allow duplicate column keys
         // must use custom accessor to allow `.` in column names

--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -737,7 +737,7 @@ export default function TableChart<D extends DataRecord = DataRecord>(
         }
       }
 
-      if (dataSelectionMode === 'None') {
+      if (dataSelectionMode === 'none') {
         className += ' no-select';
       }
 

--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -264,6 +264,7 @@ export default function TableChart<D extends DataRecord = DataRecord>(
     isUsingTimeComparison,
     basicColorFormatters,
     basicColorColumnFormatters,
+    dataSelectionMode,
   } = props;
   const comparisonColumns = [
     { key: 'all', label: t('Display all') },
@@ -736,7 +737,9 @@ export default function TableChart<D extends DataRecord = DataRecord>(
         }
       }
 
-      className += ' no-select';
+      if (dataSelectionMode === 'None') {
+        className += ' no-select';
+      }
 
       return {
         id: String(i), // to allow duplicate column keys

--- a/superset-frontend/plugins/plugin-chart-table/src/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/transformProps.ts
@@ -644,7 +644,7 @@ const transformProps = (
     basicColorFormatters,
     startDateOffset,
     basicColorColumnFormatters,
-    dataSelectionMode,
+    dataSelectionMode: dataSelectionMode ?? 'auto',
   };
 };
 

--- a/superset-frontend/plugins/plugin-chart-table/src/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/transformProps.ts
@@ -384,6 +384,7 @@ const transformProps = (
       onContextMenu,
     },
     emitCrossFilters,
+    dataSelectionMode,
   } = chartProps;
 
   const {
@@ -643,6 +644,7 @@ const transformProps = (
     basicColorFormatters,
     startDateOffset,
     basicColorColumnFormatters,
+    dataSelectionMode,
   };
 };
 

--- a/superset-frontend/plugins/plugin-chart-table/src/types.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/types.ts
@@ -146,6 +146,7 @@ export interface TableChartTransformedProps<D extends DataRecord = DataRecord> {
   basicColorFormatters?: { [Key: string]: BasicColorFormatterType }[];
   basicColorColumnFormatters?: { [Key: string]: BasicColorFormatterType }[];
   startDateOffset?: string;
+  dataSelectionMode: string;
 }
 
 export enum ColorSchemeEnum {

--- a/superset-frontend/src/components/Chart/Chart.jsx
+++ b/superset-frontend/src/components/Chart/Chart.jsx
@@ -39,6 +39,7 @@ import { ResourceStatus } from 'src/hooks/apiResources/apiResources';
 import ChartRenderer from './ChartRenderer';
 import { ChartErrorMessage } from './ChartErrorMessage';
 import { getChartRequiredFieldsMissingMessage } from '../../utils/getChartRequiredFieldsMissingMessage';
+import { findPermission } from 'src/utils/findPermission';
 
 const propTypes = {
   annotationData: PropTypes.object,
@@ -82,6 +83,7 @@ const propTypes = {
   datasetsStatus: PropTypes.oneOf(['loading', 'error', 'complete']),
   isInView: PropTypes.bool,
   emitCrossFilters: PropTypes.bool,
+  user: PropTypes.object,
 };
 
 const BLANK = {};
@@ -156,6 +158,11 @@ class Chart extends PureComponent {
     super(props);
     this.handleRenderContainerFailure =
       this.handleRenderContainerFailure.bind(this);
+      this.canExportData = findPermission(
+          'can_export_csv',
+          'SQLLab',
+          this.props.user?.roles,
+        );
   }
 
   componentDidMount() {
@@ -271,6 +278,7 @@ class Chart extends PureComponent {
             {...this.props}
             source={this.props.dashboardId ? 'dashboard' : 'explore'}
             data-test={this.props.vizType}
+            dataSelectionMode={this.canExportData ? 'auto' : 'none'}
           />
         ) : (
           <Loading />

--- a/superset-frontend/src/components/Chart/Chart.jsx
+++ b/superset-frontend/src/components/Chart/Chart.jsx
@@ -36,10 +36,10 @@ import { getUrlParam } from 'src/utils/urlUtils';
 import { isCurrentUserBot } from 'src/utils/isBot';
 import { ChartSource } from 'src/types/ChartSource';
 import { ResourceStatus } from 'src/hooks/apiResources/apiResources';
+import { findPermission } from 'src/utils/findPermission';
 import ChartRenderer from './ChartRenderer';
 import { ChartErrorMessage } from './ChartErrorMessage';
 import { getChartRequiredFieldsMissingMessage } from '../../utils/getChartRequiredFieldsMissingMessage';
-import { findPermission } from 'src/utils/findPermission';
 
 const propTypes = {
   annotationData: PropTypes.object,
@@ -158,11 +158,11 @@ class Chart extends PureComponent {
     super(props);
     this.handleRenderContainerFailure =
       this.handleRenderContainerFailure.bind(this);
-      this.canExportData = findPermission(
-          'can_export_csv',
-          'SQLLab',
-          this.props.user?.roles,
-        );
+    this.canExportData = findPermission(
+      'can_export_csv',
+      'SQLLab',
+      this.props.user?.roles,
+    );
   }
 
   componentDidMount() {

--- a/superset-frontend/src/components/Chart/Chart.jsx
+++ b/superset-frontend/src/components/Chart/Chart.jsx
@@ -159,8 +159,8 @@ class Chart extends PureComponent {
     this.handleRenderContainerFailure =
       this.handleRenderContainerFailure.bind(this);
     this.canExportData = findPermission(
-      'can_export_csv',
-      'SQLLab',
+      'can_csv',
+      'Superset',
       this.props.user?.roles,
     );
   }

--- a/superset-frontend/src/components/Chart/ChartContainer.jsx
+++ b/superset-frontend/src/components/Chart/ChartContainer.jsx
@@ -24,6 +24,12 @@ import { logEvent } from '../../logger/actions';
 import Chart from './Chart';
 import { updateDataMask } from '../../dataMask/actions';
 
+function mapStateToProps(state) {
+  return {
+    user: state.user,
+  };
+}
+
 function mapDispatchToProps(dispatch) {
   return {
     actions: bindActionCreators(
@@ -37,4 +43,4 @@ function mapDispatchToProps(dispatch) {
   };
 }
 
-export default connect(null, mapDispatchToProps)(Chart);
+export default connect(mapStateToProps, mapDispatchToProps)(Chart);

--- a/superset-frontend/src/components/Chart/ChartRenderer.jsx
+++ b/superset-frontend/src/components/Chart/ChartRenderer.jsx
@@ -48,6 +48,7 @@ const propTypes = {
   setControlValue: PropTypes.func,
   vizType: PropTypes.string.isRequired,
   triggerRender: PropTypes.bool,
+  // dataSelectionMode: PropTypes.string,
   // state
   chartAlert: PropTypes.string,
   chartStatus: PropTypes.string,
@@ -315,6 +316,8 @@ class ChartRenderer extends Component {
       );
     }
 
+    const dataSelectionMode = 'None';
+
     // Check for Behavior.DRILL_TO_DETAIL to tell if chart can receive Drill to
     // Detail props or if it'll cause side-effects (e.g. excessive re-renders).
     const drillToDetailProps = getChartMetadataRegistry()
@@ -362,6 +365,7 @@ class ChartRenderer extends Component {
             postTransformProps={postTransformProps}
             emitCrossFilters={emitCrossFilters}
             legendState={this.state.legendState}
+            dataSelectionMode={dataSelectionMode}
             {...drillToDetailProps}
           />
         </div>

--- a/superset-frontend/src/components/Chart/ChartRenderer.jsx
+++ b/superset-frontend/src/components/Chart/ChartRenderer.jsx
@@ -48,8 +48,6 @@ const propTypes = {
   setControlValue: PropTypes.func,
   vizType: PropTypes.string.isRequired,
   triggerRender: PropTypes.bool,
-  // dataSelectionMode: PropTypes.string,
-  // state
   chartAlert: PropTypes.string,
   chartStatus: PropTypes.string,
   queriesResponse: PropTypes.arrayOf(PropTypes.object),
@@ -64,6 +62,7 @@ const propTypes = {
   postTransformProps: PropTypes.func,
   source: PropTypes.oneOf([ChartSource.Dashboard, ChartSource.Explore]),
   emitCrossFilters: PropTypes.bool,
+  dataSelectionMode: PropTypes.string,
 };
 
 const BLANK = {};
@@ -265,6 +264,7 @@ class ChartRenderer extends Component {
       formData,
       latestQueryFormData,
       postTransformProps,
+      dataSelectionMode,
     } = this.props;
 
     const currentFormData =
@@ -315,8 +315,6 @@ class ChartRenderer extends Component {
         <EmptyStateSmall title={noResultTitle} image={noResultImage} />
       );
     }
-
-    const dataSelectionMode = 'None';
 
     // Check for Behavior.DRILL_TO_DETAIL to tell if chart can receive Drill to
     // Detail props or if it'll cause side-effects (e.g. excessive re-renders).

--- a/superset-frontend/src/components/FilterableTable/FilterableTable.test.tsx
+++ b/superset-frontend/src/components/FilterableTable/FilterableTable.test.tsx
@@ -20,6 +20,8 @@ import { isValidElement } from 'react';
 import FilterableTable from 'src/components/FilterableTable';
 import { render, screen, within } from 'spec/helpers/testing-library';
 import userEvent from '@testing-library/user-event';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
 
 describe('FilterableTable', () => {
   const mockedProps = {
@@ -31,12 +33,18 @@ describe('FilterableTable', () => {
     ],
     height: 500,
   };
+  const initialState = { state: { user : {role : 'test'}} };
+  const mockStore = configureStore();
+  let store;
   it('is valid element', () => {
     expect(isValidElement(<FilterableTable {...mockedProps} />)).toBe(true);
   });
   it('renders a grid with 3 Table rows', () => {
+    store = mockStore(initialState);
     const { getByRole, getByText } = render(
-      <FilterableTable {...mockedProps} />,
+      <Provider store={store}>
+      <FilterableTable {...mockedProps} />
+      </Provider>,
     );
     expect(getByRole('table')).toBeInTheDocument();
     mockedProps.data.forEach(({ b: columnBContent }) => {
@@ -48,7 +56,12 @@ describe('FilterableTable', () => {
       ...mockedProps,
       filterText: 'b1',
     };
-    const { getByText, queryByText } = render(<FilterableTable {...props} />);
+    store = mockStore(initialState);
+    const { getByText, queryByText } = render(
+      <Provider store={store}>
+      <FilterableTable {...props} />
+      </Provider>,
+    );
     expect(getByText(props.filterText)).toBeInTheDocument();
     expect(queryByText('b2')).toBeFalsy();
     expect(queryByText('b3')).toBeFalsy();
@@ -58,7 +71,12 @@ describe('FilterableTable', () => {
       ...mockedProps,
       filterText: '100',
     };
-    const { getByText, queryByText } = render(<FilterableTable {...props} />);
+    store = mockStore(initialState);
+    const { getByText, queryByText } = render(
+      <Provider store={store}>
+      <FilterableTable {...props} />
+      </Provider>,
+    );
     expect(getByText('b2')).toBeInTheDocument();
     expect(queryByText('b1')).toBeFalsy();
     expect(queryByText('b3')).toBeFalsy();
@@ -66,6 +84,9 @@ describe('FilterableTable', () => {
 });
 
 describe('FilterableTable sorting - RTL', () => {
+  const initialState = { state: { user : {role : 'test'}} };
+  const mockStore = configureStore();
+  let store;
   it('sorts strings correctly', () => {
     const stringProps = {
       orderedColumnKeys: ['columnA'],
@@ -76,7 +97,12 @@ describe('FilterableTable sorting - RTL', () => {
       ],
       height: 500,
     };
-    render(<FilterableTable {...stringProps} />);
+    store = mockStore(initialState);
+    render(
+      <Provider store={store}>
+      <FilterableTable {...stringProps} />
+      </Provider>,
+    );
 
     const stringColumn = within(screen.getByRole('table'))
       .getByText('columnA')
@@ -122,7 +148,12 @@ describe('FilterableTable sorting - RTL', () => {
       data: [{ columnB: 21 }, { columnB: 0 }, { columnB: 623 }],
       height: 500,
     };
-    render(<FilterableTable {...integerProps} />);
+    store = mockStore(initialState);
+    render(
+      <Provider store={store}>
+      <FilterableTable {...integerProps} />
+      </Provider>,
+    );
 
     const integerColumn = within(screen.getByRole('table'))
       .getByText('columnB')
@@ -157,7 +188,13 @@ describe('FilterableTable sorting - RTL', () => {
       data: [{ columnC: 45.67 }, { columnC: 1.23 }, { columnC: 89.0000001 }],
       height: 500,
     };
-    render(<FilterableTable {...floatProps} />);
+    mockStore(initialState);
+    store = mockStore(initialState);
+    render(
+      <Provider store={store}>
+      <FilterableTable {...floatProps} />
+      </Provider>,
+    );
 
     const floatColumn = within(screen.getByRole('table'))
       .getByText('columnC')
@@ -212,7 +249,12 @@ describe('FilterableTable sorting - RTL', () => {
       ],
       height: 500,
     };
-    render(<FilterableTable {...mixedFloatProps} />);
+    store = mockStore(initialState);
+    render(
+      <Provider store={store}>
+      <FilterableTable {...mixedFloatProps} />
+      </Provider>,
+    );
 
     const mixedFloatColumn = within(screen.getByRole('table'))
       .getByText('columnD')
@@ -310,7 +352,12 @@ describe('FilterableTable sorting - RTL', () => {
       ],
       height: 500,
     };
-    render(<FilterableTable {...dsProps} />);
+    store = mockStore(initialState);
+    render(
+      <Provider store={store}>
+      <FilterableTable {...dsProps} />
+      </Provider>,
+    );
 
     const dsColumn = within(screen.getByRole('table'))
       .getByText('columnDS')

--- a/superset-frontend/src/components/FilterableTable/index.tsx
+++ b/superset-frontend/src/components/FilterableTable/index.tsx
@@ -39,11 +39,11 @@ const SCROLL_BAR_HEIGHT = 15;
 const ONLY_NUMBER_REGEX = /^(NaN|-?((\d*\.\d+|\d+)([Ee][+-]?\d+)?|Infinity))$/;
 
 interface StyledFilterableTableProps {
-  canDownload?: boolean;
+  canExportData?: boolean;
 }
 
 const StyledFilterableTable = styled.div<StyledFilterableTableProps>`
-  ${({ theme, canDownload }) => `
+  ${({ theme, canExportData }) => `
     height: 100%;
     overflow: hidden;
 
@@ -57,7 +57,7 @@ const StyledFilterableTable = styled.div<StyledFilterableTableProps>`
       min-width: 0px;
       align-self: center;
       font-size: ${theme.typography.sizes.s}px;
-      user-select: ${canDownload ? 'auto' : 'none'};
+      user-select: ${canExportData ? 'auto' : 'none'};
     }
 
     .even-row {
@@ -257,8 +257,8 @@ const FilterableTable = ({
       }),
   }));
 
-  const canDownload = useSelector((state: RootState) =>
-    findPermission('can_csv', 'Superset', state.user?.roles),
+  const canExportData = useSelector((state: RootState) =>
+    findPermission('can_export_csv', 'SQLLab', state.user?.roles),
   );
 
   return (
@@ -266,7 +266,7 @@ const FilterableTable = ({
       className="filterable-table-container"
       data-test="table-container"
       ref={container}
-      canDownload={canDownload}
+      canExportData={canExportData}
     >
       {fitted && (
         <Table

--- a/superset-frontend/src/components/FilterableTable/index.tsx
+++ b/superset-frontend/src/components/FilterableTable/index.tsx
@@ -64,7 +64,6 @@ const StyledFilterableTable = styled.div`
     .cell-text-for-measuring {
       font-family: ${theme.typography.families.sansSerif};
       font-size: ${theme.typography.sizes.s}px;
-      user-select: none;
     }
   `}
 `;

--- a/superset-frontend/src/components/FilterableTable/index.tsx
+++ b/superset-frontend/src/components/FilterableTable/index.tsx
@@ -18,11 +18,14 @@
  */
 import _JSONbig from 'json-bigint';
 import { useEffect, useRef, useState, useMemo } from 'react';
+import { useSelector } from 'react-redux';
 import { getMultipleTextDimensions, styled } from '@superset-ui/core';
 import { useDebounceValue } from 'src/hooks/useDebounceValue';
 import { useCellContentParser } from './useCellContentParser';
 import { renderResultCell } from './utils';
 import { Table, TableSize } from '../Table';
+import { RootState } from 'src/dashboard/types';
+import { findPermission } from 'src/utils/findPermission';
 
 const JSONbig = _JSONbig({
   storeAsString: true,
@@ -35,8 +38,12 @@ const SCROLL_BAR_HEIGHT = 15;
 // See https://stackoverflow.com/a/30987109 for more details
 const ONLY_NUMBER_REGEX = /^(NaN|-?((\d*\.\d+|\d+)([Ee][+-]?\d+)?|Infinity))$/;
 
-const StyledFilterableTable = styled.div`
-  ${({ theme }) => `
+interface StyledFilterableTableProps {
+  canDownload?: boolean;
+}
+
+const StyledFilterableTable = styled.div<StyledFilterableTableProps>`
+  ${({ theme, canDownload }) => `
     height: 100%;
     overflow: hidden;
 
@@ -50,7 +57,7 @@ const StyledFilterableTable = styled.div`
       min-width: 0px;
       align-self: center;
       font-size: ${theme.typography.sizes.s}px;
-      user-select: none;
+      user-select: ${canDownload ? 'auto' : 'none'};
     }
 
     .even-row {
@@ -250,11 +257,16 @@ const FilterableTable = ({
       }),
   }));
 
+  const canDownload = useSelector((state: RootState) =>
+    findPermission('can_csv', 'Superset', state.user?.roles),
+  );
+
   return (
     <StyledFilterableTable
       className="filterable-table-container"
       data-test="table-container"
       ref={container}
+      canDownload={canDownload}
     >
       {fitted && (
         <Table

--- a/superset-frontend/src/components/FilterableTable/index.tsx
+++ b/superset-frontend/src/components/FilterableTable/index.tsx
@@ -21,11 +21,11 @@ import { useEffect, useRef, useState, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { getMultipleTextDimensions, styled } from '@superset-ui/core';
 import { useDebounceValue } from 'src/hooks/useDebounceValue';
+import { RootState } from 'src/dashboard/types';
+import { findPermission } from 'src/utils/findPermission';
 import { useCellContentParser } from './useCellContentParser';
 import { renderResultCell } from './utils';
 import { Table, TableSize } from '../Table';
-import { RootState } from 'src/dashboard/types';
-import { findPermission } from 'src/utils/findPermission';
 
 const JSONbig = _JSONbig({
   storeAsString: true,

--- a/superset-frontend/src/components/FilterableTable/index.tsx
+++ b/superset-frontend/src/components/FilterableTable/index.tsx
@@ -50,6 +50,7 @@ const StyledFilterableTable = styled.div`
       min-width: 0px;
       align-self: center;
       font-size: ${theme.typography.sizes.s}px;
+      user-select: none;
     }
 
     .even-row {
@@ -63,6 +64,7 @@ const StyledFilterableTable = styled.div`
     .cell-text-for-measuring {
       font-family: ${theme.typography.families.sansSerif};
       font-size: ${theme.typography.sizes.s}px;
+      user-select: none;
     }
   `}
 `;


### PR DESCRIPTION
This PR disables data selection depending upon role for:
- The main SQLLab results table, controlled by role `can_export_csv` on `SQLLab`
- Chart Tables, controlled by role `can_csv` on Superset`
- Chart Pivot tables, controlled by role `can_csv` on `Superset`

Resolves: https://github.com/konzainc/konza-kube/issues/353